### PR TITLE
Bugfixes from upstream

### DIFF
--- a/src/core/format.coffee
+++ b/src/core/format.coffee
@@ -69,12 +69,14 @@ class Format
     bullet:
       type: Format.types.LINE
       exclude: 'list'
+      inherit: true
       parentTag: 'UL'
       tag: 'LI'
 
     list:
       type: Format.types.LINE
       exclude: 'bullet'
+      inherit: true
       parentTag: 'OL'
       tag: 'LI'
 

--- a/src/modules/keyboard.coffee
+++ b/src/modules/keyboard.coffee
@@ -68,19 +68,21 @@ class Keyboard
       [leaf, offset] = line.findLeafAt(offset)
       delta = new Delta().retain(range.start)
 
-      # hitting enter on an empty line formatted as a list should remove the format
+      # if on an empty line formatted as a list, remove the format
       if range.isCollapsed() and line.length == 1 and (line.formats.bullet or line.formats.list)
         delta.retain(1, { list: false, bullet: false })
       else
         delta.insert('\n', line.formats).delete(range.end - range.start)
 
+      # if creating a new empty line (was at the end of the old line),
       # remove line formats from the new line that should not be inherited
-      delta.retain(1, _.reduce(line.formats, (formats, value, name) =>
-        format = @quill.editor.doc.formats[name]
-        if format and format.isType('line') and !format.config.inherit
-          formats[name] = false
-        return formats
-      , {}))
+      if !leaf.next and offset == leaf.length
+        delta.retain(1, _.reduce(line.formats, (formats, value, name) =>
+          format = @quill.editor.doc.formats[name]
+          if format and format.isType('line') and !format.config.inherit
+            formats[name] = false
+          return formats
+        , {}))
 
       @quill.updateContents(delta, Quill.sources.USER)
       _.each(leaf.formats, (value, format) =>

--- a/src/modules/keyboard.coffee
+++ b/src/modules/keyboard.coffee
@@ -106,7 +106,7 @@ class Keyboard
       if range? and @quill.getLength() > 0
         if range.start != range.end
           before = @quill.getText(Math.max(range.start - 1, 0), range.start)
-          after = @quill.getText(range.end, Math.max(range.end + 1, @quill.getLength()))
+          after = @quill.getText(range.end, Math.min(range.end + 1, @quill.getLength()))
           if ' ' == before == after
             range.start = range.start - 1
           @quill.deleteText(range.start, range.end, Quill.sources.USER)

--- a/src/modules/keyboard.coffee
+++ b/src/modules/keyboard.coffee
@@ -67,22 +67,29 @@ class Keyboard
       [line, offset] = @quill.editor.doc.findLineAt(range.start)
       [leaf, offset] = line.findLeafAt(offset)
       delta = new Delta().retain(range.start)
+      removeInheritedFormats = _.reduce(line.formats, (formats, value, name) =>
+        format = @quill.editor.doc.formats[name]
+        if format and format.isType('line') and format.config.inherit
+          formats[name] = false
+        return formats
+      , {})
+      removeNonInheritedFormats = _.reduce(line.formats, (formats, value, name) =>
+        format = @quill.editor.doc.formats[name]
+        if format and format.isType('line') and !format.config.inherit
+          formats[name] = false
+        return formats
+      , {})
 
-      # if on an empty line formatted as a list, remove the format
-      if range.isCollapsed() and line.length == 1 and (line.formats.bullet or line.formats.list)
-        delta.retain(1, { list: false, bullet: false })
+      # if on an empty line, remove the inheritable formats
+      if range.isCollapsed() and line.length == 1 and Object.keys(removeInheritedFormats).length > 0
+        delta.retain(1, removeInheritedFormats)
       else
         delta.insert('\n', line.formats).delete(range.end - range.start)
 
       # if creating a new empty line (was at the end of the old line),
       # remove line formats from the new line that should not be inherited
       if !leaf.next and offset == leaf.length
-        delta.retain(1, _.reduce(line.formats, (formats, value, name) =>
-          format = @quill.editor.doc.formats[name]
-          if format and format.isType('line') and !format.config.inherit
-            formats[name] = false
-          return formats
-        , {}))
+        delta.retain(1, removeNonInheritedFormats)
 
       @quill.updateContents(delta, Quill.sources.USER)
       _.each(leaf.formats, (value, format) =>

--- a/src/modules/keyboard.coffee
+++ b/src/modules/keyboard.coffee
@@ -66,7 +66,22 @@ class Keyboard
       return true unless range?
       [line, offset] = @quill.editor.doc.findLineAt(range.start)
       [leaf, offset] = line.findLeafAt(offset)
-      delta = new Delta().retain(range.start).insert('\n', line.formats).delete(range.end - range.start)
+      delta = new Delta().retain(range.start)
+
+      # hitting enter on an empty line formatted as a list should remove the format
+      if range.isCollapsed() and line.length == 1 and (line.formats.bullet or line.formats.list)
+        delta.retain(1, { list: false, bullet: false })
+      else
+        delta.insert('\n', line.formats).delete(range.end - range.start)
+
+      # remove line formats from the new line that should not be inherited
+      delta.retain(1, _.reduce(line.formats, (formats, value, name) =>
+        format = @quill.editor.doc.formats[name]
+        if format and format.isType('line') and !format.config.inherit
+          formats[name] = false
+        return formats
+      , {}))
+
       @quill.updateContents(delta, Quill.sources.USER)
       _.each(leaf.formats, (value, format) =>
         @quill.prepareFormat(format, value)

--- a/src/modules/keyboard.coffee
+++ b/src/modules/keyboard.coffee
@@ -105,6 +105,10 @@ class Keyboard
     this.addHotkey([dom.KEYS.DELETE, dom.KEYS.BACKSPACE], (range, hotkey) =>
       if range? and @quill.getLength() > 0
         if range.start != range.end
+          before = @quill.getText(Math.max(range.start - 1, 0), range.start)
+          after = @quill.getText(range.end, Math.max(range.end + 1, @quill.getLength()))
+          if ' ' == before == after
+            range.start = range.start - 1
           @quill.deleteText(range.start, range.end, Quill.sources.USER)
         else
           if hotkey.key == dom.KEYS.BACKSPACE

--- a/test/unit/modules/keyboard.coffee
+++ b/test/unit/modules/keyboard.coffee
@@ -31,6 +31,55 @@ describe('Keyboard', ->
     )
   )
 
+  describe('enter key', ->
+    beforeEach( ->
+      @container.innerHTML = '<div><div>01234</div></div>'
+      @quill = new Quill(@container.firstChild)
+      @keyboard = @quill.getModule('keyboard')
+      @enterKey = { key: dom.KEYS.ENTER }
+    )
+
+    it('inserts a newline', ->
+      @quill.setSelection(2, 2)
+      dom(@quill.root).trigger('keydown', @enterKey)
+      expect(@quill.root).toEqualHTML('<div>01</div><div>234</div>')
+    )
+
+    it('replaces selected text with a newline', ->
+      @quill.setSelection(2, 3)
+      dom(@quill.root).trigger('keydown', @enterKey)
+      expect(@quill.root).toEqualHTML('<div>01</div><div>34</div>')
+    )
+
+    it('inherits line formats when breaking a line in two', ->
+      @quill.formatText(5, 6, 'align', 'right')
+      @quill.setSelection(2, 2)
+      dom(@quill.root).trigger('keydown', @enterKey)
+      expect(@quill.root).toEqualHTML('<div style="text-align: right;">01</div><div style="text-align: right;">234</div>')
+    )
+
+    it('does not inherit line formats when inserting a blank line', ->
+      @quill.formatText(5, 6, 'align', 'right')
+      @quill.setSelection(5, 5)
+      dom(@quill.root).trigger('keydown', @enterKey)
+      expect(@quill.root).toEqualHTML('<div style="text-align: right;">01234</div><div><br></div>')
+    )
+
+    it('inherits line formats for formats with "inherit: true" specified', ->
+      @quill.formatText(5, 6, 'list', true)
+      @quill.setSelection(5, 5)
+      dom(@quill.root).trigger('keydown', @enterKey)
+      expect(@quill.root).toEqualHTML('<ol><li>01234</li><li><br></li></ol>')
+    )
+
+    it('removes the list format when starting from an empty line', ->
+      @quill.setHTML('<ol><li>one</li><li><br></li></ol>')
+      @quill.setSelection(4, 4)
+      dom(@quill.root).trigger('keydown', @enterKey)
+      expect(@quill.root).toEqualHTML('<ol><li>one</li></ol><div><br></div>')
+    )
+  )
+
   describe('hotkeys', ->
     beforeEach( ->
       @container.innerHTML = '<div><div>0123</div></div>'


### PR DESCRIPTION
These are all bugfixes found on the upstream repo, `quilljs/quill`, that have either been merged with their `develop` branch or have been LGTM'd. Because the `master` branch on the upstream repo is no longer maintained, all new bugfixes are going to `develop` instead. We don't want to switch to `develop` until it's stable, so we're cherry picking bugfixes and small features to solve issues we're having with quill.

This PR includes:
- hitting enter on an empty line with a line format (bullet/number list) deletes the bullet, instead of adding more empty bullets (https://github.com/quilljs/quill/pull/368)
- when deleting a word, if it is preceded by and followed by a space, delete one of them (https://github.com/quilljs/quill/pull/301)
- fixes errors around ranges not existing
