### PR TITLE
BUGS-998: Do not normalize null nodes as a result of nested lists.

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "grunt-lodash": "~0.4.0",
     "grunt-protractor-runner": "~2.0.0",
     "grunt-sauce-connect-launcher": "~0.3.0",
-    "harp": "~0.17.0",
+    "harp": "~0.23.0",
     "http-proxy": "~1.11.1",
     "istanbul": "~0.3.5",
     "jasmine-core": "~2.3.4",

--- a/src/core/document.coffee
+++ b/src/core/document.coffee
@@ -81,7 +81,8 @@ class Document
     lineNode = lineNode.firstChild if lineNode? and dom.LIST_TAGS[lineNode.tagName]?
     _.each(lines, (line, index) =>
       while line.node != lineNode
-        if line.node.parentNode == @root or line.node.parentNode?.parentNode == @root
+        # https://github.com/quilljs/quill/pull/408
+        if lineNode && (line.node.parentNode == @root or line.node.parentNode?.parentNode == @root)
           # New line inserted
           lineNode = @normalizer.normalizeLine(lineNode)
           newLine = this.insertLineBefore(lineNode, line)


### PR DESCRIPTION
https://leverapp.atlassian.net/browse/BUGS-998

This PR patches an issue where nested lists in the following format would crash the editor.

```html
<div>
  <div>
    <ol>
      <ol>
```

### Concerns

* This introduces a new issue where any typing/deltas after a nested list is broken. This is generally fine b/c people normally do not edit email replies.

* Another issue that is not handled is the following.

```
<ol>
  <ol>
```

This crashes the editor, and there are no good fixes for this.